### PR TITLE
Point v7 subdomain to MUI X v7 docs

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -530,11 +530,11 @@ https://v4.material-ui.com/* https://v4.mui.com/:splat 301!
 ## MUI X
 ## Unlike the store that expect to be hosted under a subfolder,
 ## MUI X is configured to be hosted at the root.
-/static/x/* https://material-ui-x.netlify.app/static/x/:splat 200
-/x/_next/* https://material-ui-x.netlify.app/_next/:splat 200
-/x/* https://material-ui-x.netlify.app/x/:splat 200
-/r/x-* https://material-ui-x.netlify.app/r/x-:splat 200
-/:lang/x/* https://material-ui-x.netlify.app/:lang/x/:splat 200
+/static/x/* https://docs-v7--material-ui-x.netlify.app/static/x/:splat 200
+/x/_next/* https://docs-v7--material-ui-x.netlify.app/_next/:splat 200
+/x/* https://docs-v7--material-ui-x.netlify.app/x/:splat 200
+/r/x-* https://docs-v7--material-ui-x.netlify.app/r/x-:splat 200
+/:lang/x/* https://docs-v7--material-ui-x.netlify.app/:lang/x/:splat 200
 
 ## Toolpad
 /toolpad/core/templates/nextjs-dashboard/_next/* https://toolpad-core-nextjs-themed.vercel.app/_next/:splat 200


### PR DESCRIPTION
Since there's no v7 docs branch in the `material-ui` repo, this seems to be the only place to apply this change to.
Currently, https://mui.com/x/introduction/ points to MUI X v8 docs because of these redirects

<img width="423" src="https://github.com/user-attachments/assets/1036a8d6-1a60-48c5-a101-1340df282689" />
