### PR TITLE
Fix Search Results for v7

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -447,7 +447,7 @@ export default function AppSearch(props) {
             initialQuery={initialQuery}
             appId="TZGZ85B9TB"
             apiKey="8177dfb3e2be72b241ffb8c5abafa899"
-            indexName="material-ui"
+            indexName="material-ui-v7"
             searchParameters={{
               facetFilters: ['version:master', facetFilterLanguage],
               optionalFilters,


### PR DESCRIPTION
Uses a [separate index](https://dashboard.algolia.com/apps/TZGZ85B9TB/explorer/browse/material-ui-v7) based on https://v7.mui.com/

Adds a [new crawler](https://dashboard.algolia.com/apps/TZGZ85B9TB/crawler/crawler/94aa77a1-dfed-449a-af6b-49730d99be65/overview) that crawls once a month.

Fix: https://github.com/mui/material-ui/issues/45771